### PR TITLE
Speed limiter rework

### DIFF
--- a/6y300.xml
+++ b/6y300.xml
@@ -75,8 +75,6 @@
 </table>
 <table name="Speed Limiter" storageaddress="0x5074" />
 
-<table name="Speed Limiter (km/h)" storageaddress="0x5074" />
-
 <table name="QH0/ torque conversion map" storageaddress="0x644c">
 	<table type="X Axis" storageaddress="0x794a" />
 	<table type="Y Axis" storageaddress="0x6e0b" />

--- a/6y303.xml
+++ b/6y303.xml
@@ -67,7 +67,8 @@
 <table name="Idle Target 2" storageaddress="0x7403"/>
 <table name="Fuel Injection Multiplier" storageaddress="0x500c"/>
 <table name="Speed Limiter" storageaddress="0x50b2" />
-<table name="Speed Limiter (km/h)" storageaddress="0x50b2" />
+<table name="mVSPCT2 Speed Limiter (cut)" storageaddress="0x4e43"/>
+<table name="mVSPRC2 Speed Limiter (restore)" storageaddress="0x4e4e"/>
 
 <table name="QH0/ torque conversion map" storageaddress="0x85fc">
 	<table type="X Axis" storageaddress="0x88d0" />

--- a/8U523.xml
+++ b/8U523.xml
@@ -54,6 +54,8 @@
 <table name="Rev Limit (Fuel Cut)" storageaddress="0x539e">
 </table>
 
+<table name="Speed Limiter" storageaddress="0x5440" />
+
 <table name="No Load Rev Limit (Fuel Cut)" storageaddress="0x53a2">
 </table>
 

--- a/9J074.xml
+++ b/9J074.xml
@@ -61,7 +61,6 @@
 <table name="Fuel Injection Multiplier" storageaddress="0x4FD0">
 </table>
 <table name="Speed Limiter" storageaddress="0x5074" />
-<table name="Speed Limiter (km/h)" storageaddress="0x5074" />
 <table name="QH0/ torque conversion map" storageaddress="0x85dc">
 	<table type="X Axis" storageaddress="0x88b0" />
 	<table type="Y Axis" storageaddress="0x8820" />

--- a/am900.xml
+++ b/am900.xml
@@ -71,7 +71,7 @@
 <table name="Fuel Injection Multiplier" storageaddress="0x6428">
 </table>
 
-<table name="Speed Limiter (km/h)" storageaddress="0x64ea" />
+<table name="Speed Limiter" storageaddress="0x64ea" />
 
 <checksum type="std" start="0" end="0x7FFFF" sumloc="0x6640" xorloc="0x6638" />
 

--- a/aq806.xml
+++ b/aq806.xml
@@ -58,7 +58,7 @@
 	<table name="No Load Rev Limit (Fuel Cut)" storageaddress="0x4a44">
 	</table>
 	
-	<table name="Speed Limiter (km/h)" storageaddress="0x4ac0" />
+	<table name="Speed Limiter" storageaddress="0x4ac0" />
 	
 	<table name="Engine torque value map" storageaddress="0x71f8">
 	<table type="X Axis" storageaddress="0x7816" />

--- a/cd700.xml
+++ b/cd700.xml
@@ -46,8 +46,10 @@
 <table name="Intake Cam Timing (16x16)" storageaddress="0x6c11">
       <table type="X Axis" storageaddress="0x87f1" />
       <table type="Y Axis" storageaddress="0x8801" />
-    </table>
-    
+</table>
+
+<table name="Speed Limiter" storageaddress="0x6268" />
+	
 <table name="Rev Limit (Fuel Cut)" storageaddress="0x61dc">
 </table>
 

--- a/table_templates
+++ b/table_templates
@@ -5,6 +5,11 @@
    <flashmethod>nisprog</flashmethod>
   </romid>
 
+
+<!-- Some scalings. Names inspired from ZB060 A2L. Haven't managed to get global scalings to work... -->
+<scaling name="u8speed_COMP_0007" units="km/h" expression="x*2" to_byte="x/2" format="0.0" fineincrement="2" coarseincrement="10" />
+<scaling name="u8speed_COMP_0007_imp" units="mph" expression="x*2/1.6" to_byte="x*1.6/2" format="0.0" fineincrement="2" coarseincrement="10" />
+
     <table type="3D" name="Cold Ignition Trim" category="Ignition Timing" storagetype="uint8" endian="big" sizex="16" sizey="16" userlevel="1" logparam="?">
       <scaling units="Degrees Advance" expression="x-64" to_byte="x+64" format="0" fineincrement="1" coarseincrement="4" />
       <table type="X Axis" name="Load" storagetype="uint8" endian="big" logparam="?">
@@ -556,19 +561,32 @@
 </table>
 
 <table type="2D" name="Speed Limiter" category="Limiters" storagetype="uint16" endian="big" sizey="1" userlevel="1">
-   <scaling units="" expression="x*.0621371" to_byte="x/.0621371" format="0.00" fineincrement="1" coarseincrement="10" />
-   <table type="Static Y Axis" name="MPH" sizey="2">
-    <data>K Value</data>
+	<scaling name="SI" units="km/h" expression="x*0.1" to_byte="x/0.1" format="0.0" fineincrement="1" coarseincrement="10" />
+	<scaling name="imp" units="mph" expression="x*.0621371" to_byte="x/.0621371" format="0.00" fineincrement="1" coarseincrement="10" />
+	<table type="Static Y Axis" name="Limit" sizey="1">
+		<data>speed</data>
    </table>
    <description>Speed Limiter</description>
 </table>
 
-<table type="2D" name="Speed Limiter (km/h)" category="Limiters" storagetype="uint16" endian="big" sizey="1" userlevel="1">
-   <scaling units="" expression="x*0.1" to_byte="x/0.1" format="0.0" fineincrement="1" coarseincrement="10" />
-   <table type="Static Y Axis" name="km/h" sizey="2">
-    <data>K Value</data>
+<table type="2D" name="mVSPCT2 Speed Limiter (cut)" category="Limiters" storagetype="uint8" endian="big" sizey="1" userlevel="1" >
+	<!-- scalings from ZB060 A2L, seem to be valid for all 8-bit (low resolution) vehicle speed params -->
+	<scaling name="SI" units="km/h" expression="x*2" to_byte="x/2" format="0.0" fineincrement="2" coarseincrement="10" />
+	<scaling name="imp" units="mph" expression="x*2/1.6" to_byte="x*1.6/2" format="0.0" fineincrement="1" coarseincrement="10" />
+	<table type="Static Y Axis" name="fuel cut" sizey="1">
+		<data>speed</data>
    </table>
-   <description>Speed Limiter</description>
+	<description>Speed Limiter. Some ROMs have two speed limiting mechanisms (mVSPCT2 and the other generically named "speed limiter")</description>
+</table>
+
+<table type="2D" name="mVSPRC2 Speed Limiter (restore)" category="Limiters" storagetype="uint8" endian="big" sizey="1" userlevel="1">
+	<!-- scaling from ZB060 A2L ("COMP_0007"), seems to be used for all 8-bit (low resolution) vehicle speed params -->
+	<scaling name="km" units="km/h" expression="x*2" to_byte="x/2" format="0.0" fineincrement="2" coarseincrement="10" />
+	<scaling name="mp" units="mph" expression="x*2/1.6" to_byte="x*1.6/2" format="0.0" fineincrement="1" coarseincrement="10" />
+	<table type="Static Y Axis" name="fuel restore" sizey="1">
+		<data>speed</data>
+	</table>
+	<description>Speed Limiter. Some ROMs have two speed limiting mechanisms (mVSPCT2 and the other generically named "speed limiter"). This speed (restore) must be lower than cut</description>
 </table>
 
 <table type="2D" name="Throttle Rev Limit" category="Limiters" storagetype="uint16" endian="big" sizey="1" userlevel="1">


### PR DESCRIPTION
- existing speed limiter def : removed separate "km/h" template, instead
use multiple scalings
- add A2L based mVSPCT2,mVSPRC2 cut/restore limiter to templates and
6Y303 (untested)